### PR TITLE
Fix dark mode toggle class removal

### DIFF
--- a/scripts/toggle-dark-mode.js
+++ b/scripts/toggle-dark-mode.js
@@ -22,13 +22,8 @@ $(document).ready(function() {
   }
 
   checkbox.addEventListener('change', function() {
-      // Remove the current theme class from the body
-      document.body.classList.remove('body-light-theme');
-      document.body.classList.remove('body-dark-theme');
-      document.documentElement.classList.remove('root-light-theme');
-      document.documentElement.classList.remove('root-dark-theme');
-      document.body.classList.remove('a-light-theme');
-      document.body.classList.remove('a-dark-theme');
+      // Remove the current theme classes
+      removePreviousClass();
 
       // Add the new theme class to the body
       if (localStorage.getItem('theme') == 'light') {


### PR DESCRIPTION
## Summary
- fix dark mode toggle handler to correctly clear existing theme classes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841599dbbe0832f8228669d03c66e00